### PR TITLE
Remove reinstalls wrt base environment

### DIFF
--- a/create-env
+++ b/create-env
@@ -84,10 +84,10 @@ rm -rf geant4.${geant4_version}.tar.gz geant4.${geant4_version}
 announce "Installing additional software not present in base_environment"
 #python3 -m pip install numpy==1.22.4
 #python3 -m pip install numba==0.55.2
-python3 -m pip install uproot==4.3.7
+#python3 -m pip install uproot==4.3.7
 #python3 -m pip install awkward==1.10.1
 #python3 -m pip install wfsim==1.0.2
-python3 -m pip install epix==0.3.5
+#python3 -m pip install epix==0.3.5
 
 # hack to make thisroot.sh work in the minimal /bin/sh used
 # when starting the Singularity container

--- a/create-env
+++ b/create-env
@@ -89,6 +89,14 @@ announce "Installing additional software not present in base_environment"
 #python3 -m pip install wfsim==1.0.2
 #python3 -m pip install epix==0.3.5
 
+# Cloning master branch of nestpy as of 28.09.2023
+# Reason behind is that the v2.0.1 tag does not point to the v2.0.1 installation
+git clone https://github.com/NESTCollaboration/nestpy.git
+cd nestpy
+git submodule update --init --recursive
+pip install .
+cd ..
+
 # hack to make thisroot.sh work in the minimal /bin/sh used
 # when starting the Singularity container
 cp /tmp/thisroot.sh /opt/geant4/bin/thisroot.sh


### PR DESCRIPTION
As it is now, we do not need to install any additional python package in the MC environment with respect to the base_environment (except for those ensuring the C++ libraries work for Geant4/ROOT business).

I also add a nestpy install from source, since their released version does not point to the tagged one (which is the one we need for fuse). See https://github.com/NESTCollaboration/nestpy/issues/103.

cc @dachengx